### PR TITLE
Add missing libraries to Factor image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
         wget \
         ca-certificates \
+        libssl-dev \
+        libsqlite3-dev \
+        zlib1g-dev \
+        libpq-dev \
+        libsnappy-dev \
     ; \
     rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
Adds missing libraries

libcrypto.so
libsqlite3.so
libz.so
libpq.so
libsnappy.so

Do not add
libGL.so.1 -> OpenGL -> not needed
libXi.so -> X Windows manager -> not needed
libgdk-x11-2.0.so -> GTK+ -> not needed
libgmodule-2.0.so -> GLib -> not needed