### PR TITLE
Preload extras + improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,20 +25,20 @@ RUN set -ex; \
 # Add the test framework
 RUN set -ex; \
     mkdir -p /opt/factor/work; \
-    mkdir -p /opt/factor/pre; \
     mkdir -p /tmp/testest; \
     wget -q -O - https://github.com/codewars/testest/archive/refs/tags/v${TESTEST_VERSION}.tar.gz | tar xz -C /tmp/testest --strip-components=1; \
     cd /tmp/testest; \
     mv tools /opt/factor/work; \
-    mv codewars /opt/factor/work; \
-    mv math /opt/factor/pre; \
+    mv math /opt/factor/work; \
     rm -rf /tmp/testest;
+
+ADD src/imager.factor /tmp/imager.factor
 
 # Install Factor
 RUN set -ex; \
     cd /opt; \
     wget -q -O - https://downloads.factorcode.org/releases/${FACTOR_VERSION}/factor-linux-x86-64-${FACTOR_VERSION}.tar.gz | tar xzf -; \
-# To minimize the size, remove misc/ (editor support, icons), some of extra/ (extra libs and apps)
+# To minimize the size, remove misc/ (editor support, icons), some of extra/ (extra libs, apps and demos)
     cd /opt/factor; \
     rm -rf \
         ./misc \
@@ -54,10 +54,38 @@ RUN set -ex; \
         ./extra/project-euler \
         ./extra/rosetta-code \
         ./extra/audio/engine/test \
-        ./extra/talks \
+        ./extra/cuda/gl \
+        ./extra/fluids \
+        ./extra/game \
+        ./extra/gml \
+        ./extra/mason/test \
+        ./extra/model-viewer \
+        ./extra/papier \
+        ./extra/taxes/usa/mn \
+        ./extra/webapps \
+        ./extra/chipmunk/demo \
+        ./extra/euler \
+        ./extra/gamelib \
+        ./extra/opengl \
+        ./extra/terrain \
+        ./extra/L-system \
+        ./extra/boids \
+        ./extra/bubble-chamber \
+        ./extra/golden-section \
+        ./extra/gtk-samples \
+        ./extra/jamshred \
+        ./extra/math/splines/testing \
+        ./extra/math/splines/viewer \
+        ./extra/maze \
+        ./extra/nehe \
+        ./extra/processing \
+        ./extra/spheres \
+        ./extra/trails \
+        ./extra/roms \
     ; \
 # reimage factor.image
-    ./factor -factor-version="$FACTOR_VERSION" -testest-version="$TESTEST_VERSION" -run=codewars.imager;
+  ./factor -factor-version="$FACTOR_VERSION" -testest-version="$TESTEST_VERSION" /tmp/imager.factor; \
+  rm /tmp/imager.factor;
 
 ENV PATH=/opt/factor:$PATH \
     FACTOR_ROOTS=/workspace

--- a/src/imager.factor
+++ b/src/imager.factor
@@ -1,0 +1,13 @@
+USING: memory namespaces sequences system vocabs.hierarchy vocabs.loader ;
+IN: codewars.imager
+
+"resource:extra" vocab-roots get remove [ load-root ] each
+
+! Preload useful/common vocabs from extras
+{ "arrays" "assocs" "combinators" "coroutines" "decimals" "generators"
+"grouping" "infix" "lists" "lru-cache" "math" "multisets" "pair-rocket"
+"pairs" "path-finding" "qw" "sequences" "sets" "sorting" "splitting"
+"trees" "variants" }
+[ load ] each
+
+image-path save-image-and-exit


### PR DESCRIPTION
Details of changes in this branch:
1. Replaces the imaging script from `testest` with a new one in this repository, which is a more appropriate location in my opinion. (solves #13)
2. The imaging script preloads `core` and `basis` as before, but also preloads a collection of useful/commonly used vocabs from `extras` (this solves #11)
3. The imaging script is no longer installed as a permanent vocab (solves #14 )
4. Removes many additional vocabs from `extras` which were unusable due to relying on other vocabs which were already removed. (mostly games, demos, etc) (solves #15)
5. Installs `math.margins` from `testest` to `work` instead of making a new, prioritised vocab root `pre`. For 0.99 this should not change anything, but prevents breaking future versions if they add a `math.margins` vocab. (solves #16)

I would appreciate reviews from both @kazk and @nomennescio to make sure I haven't overlooked something important.